### PR TITLE
Ensure storage file is writable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "php" : "^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.0"
+        "phpunit/phpunit": "^5.0",
+        "mikey179/vfsStream": "^1.6"
     },
     "autoload": {
         "psr-4": {

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -33,6 +33,10 @@ class Valuestore implements ArrayAccess, Countable
      */
     protected function setFileName(string $fileName)
     {
+        if (file_exists($fileName) && ! is_writable($fileName)) {
+            throw new \RuntimeException("{$fileName} is not writable");
+        }
+
         $this->fileName = $fileName;
 
         return $this;

--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -3,8 +3,8 @@
 namespace Spatie\Valuestore\Test;
 
 use org\bovigo\vfs\vfsStream;
-use org\bovigo\vfs\vfsStreamDirectory;
 use Spatie\Valuestore\Valuestore;
+use org\bovigo\vfs\vfsStreamDirectory;
 
 class ValuestoreTest extends \PHPUnit_Framework_TestCase
 {
@@ -391,5 +391,17 @@ class ValuestoreTest extends \PHPUnit_Framework_TestCase
         $this->valuestore->flush();
 
         $this->assertFileNotExists($this->storageFile);
+    }
+
+    /** @test */
+    public function it_checks_if_file_is_writable()
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("{$this->storageFile} is not writable");
+
+        $file = vfsStream::newFile('storage.json', 0444);
+        $this->root->addChild($file);
+
+        Valuestore::make($this->storageFile);
     }
 }

--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Valuestore\Test;
 
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use Spatie\Valuestore\Valuestore;
 
 class ValuestoreTest extends \PHPUnit_Framework_TestCase
@@ -12,15 +14,15 @@ class ValuestoreTest extends \PHPUnit_Framework_TestCase
     /** @var \Spatie\Valuestore\Valuestore */
     protected $valuestore;
 
+    /** @var vfsStreamDirectory */
+    private $root;
+
     public function setUp()
     {
         parent::setUp();
 
-        $this->storageFile = __DIR__.'/temp/storage.json';
-
-        if (file_exists($this->storageFile)) {
-            unlink($this->storageFile);
-        }
+        $this->root = vfsStream::setup();
+        $this->storageFile = vfsStream::url('root/storage.json');
 
         $this->valuestore = Valuestore::make($this->storageFile);
     }

--- a/tests/temp/.gitignore
+++ b/tests/temp/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
At the moment there is no check for write permissions on the storage file on instantiation of the Valuestore. This PR adds this check to detect permission problems on object instantiation.

I also added a virtual file system for testing to ensure testability of this feature.