### PR TITLE
Return early on `put` if empty array

### DIFF
--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -55,7 +55,7 @@ class Valuestore implements ArrayAccess, Countable
      */
     public function put($name, $value = null)
     {
-        if ($name = []) {
+        if ($name == []) {
             return $this;
         }
 

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -55,6 +55,10 @@ class Valuestore implements ArrayAccess, Countable
      */
     public function put($name, $value = null)
     {
+        if ($name = []) {
+            return $this;
+        }
+
         $newValues = $name;
 
         if (! is_array($name)) {

--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -52,6 +52,17 @@ class ValuestoreTest extends \PHPUnit_Framework_TestCase
     }
 
     /** @test */
+    public function it_can_skip_writing_to_disk_if_putting_empty_array()
+    {
+        $this->valuestore->put('key', 'value');
+        touch($this->storageFile, 101);
+
+        $this->valuestore->put([]);
+
+        $this->assertEquals(filemtime($this->storageFile), 101);
+    }
+
+    /** @test */
     public function it_can_push_a_value_to_a_non_existing_key()
     {
         $this->valuestore->push('key', 'value');


### PR DESCRIPTION
Just added an early return in `put` if the first argument is an empty array.

### Just show me the code

Before:

`$store->put([])` will write to disk - with no changes.

After:

`$store->put([])` will not write to disk.

### Use case

I'm using this for a simple store to keep custom `meta` keys on my api that the developer can dynamically add to.

In my controller I quickly parse out all the new custom keys and throw it at the store. It is very rare that there will be new keys, and it will mean if I throw an empty array at it that it will write to disk even though I haven't added anything on every request made to that specific endpoint.

I'm currently doing this in my code as I wrap you package, but thought you may want to include it. Not a big change, but its all the little things.

---

Loving this little package. Thanks very much for sharing - postcard will be in the mail!