### PR TITLE
Using assertEmpty and assertNotEmpty assertions

### DIFF
--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -388,17 +388,17 @@ class ValuestoreTest extends TestCase
     /** @test */
     public function it_implements_array_access()
     {
-        $this->assertFalse(isset($this->valuestore['key']));
+        $this->assertEmpty($this->valuestore['key']);
 
         $this->valuestore['key'] = 'value';
 
-        $this->assertTrue(isset($this->valuestore['key']));
+        $this->assertNotEmpty($this->valuestore['key']);
 
         $this->assertSame('value', $this->valuestore['key']);
 
         unset($this->valuestore['key']);
 
-        $this->assertFalse(isset($this->valuestore['key']));
+        $this->assertEmpty($this->valuestore['key']);
 
         $this->assertNull($this->valuestore['key']);
     }


### PR DESCRIPTION
# Changed log
- Using `assertEmpty` to check the actual value is empty.
- Using `assertNotEmpty` to check actual value is not empty.