### PR TITLE
Add set as alias to put

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ $valuestore->flush(); // Empty the entire valuestore
 
 $valuestore->flushStartingWith('somekey'); // remove all items whose keys start with "somekey"
 
-$valuestore->increment('number'); // $valuestore->get('number') will return 1 
+$valuestore->increment('number'); // $valuestore->get('number') will return 1
 $valuestore->increment('number'); // $valuestore->get('number') will return 2
 $valuestore->increment('number', 3); // $valuestore->get('number') will return 5
 
@@ -93,7 +93,7 @@ You can call the following methods on the `Valuestore`
  *
  * @param string|array $name
  * @param string|int|null $value
- * 
+ *
  * @return $this
  */
 public function put($name, $value = null)
@@ -182,7 +182,7 @@ public function forget(string $key)
 /**
  * Get and forget a value from the store.
  *
- * @param string $name 
+ * @param string $name
  *
  * @return null|string
  */
@@ -241,6 +241,22 @@ public function push(string $name, $pushValue)
 public function prepend(string $name, $prependValue)
 ```
 
+### set
+
+This is an alias to [the `put` method](https://github.com/spatie/valuestore#put).
+
+```php
+/**
+ * Set a value in the store.
+ *
+ * @param string|array $name
+ * @param string|int|null $value
+ *
+ * @return $this
+ */
+public function set($name, $value = null)
+```
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information about what has changed recently.
@@ -277,7 +293,7 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -73,6 +73,19 @@ class Valuestore implements ArrayAccess, Countable
     }
 
     /**
+     * set a value in the store.
+     *
+     * @param string|array    $name
+     * @param string|int|null $value
+     *
+     * @return $this
+     */
+    public function set($name, $value = null)
+    {
+        return $this->put(...func_get_args());
+    }
+
+    /**
      * Push a new value into an array.
      *
      * @param string $name

--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -53,6 +53,14 @@ class ValuestoreTest extends TestCase
     }
 
     /** @test */
+    public function it_can_use_set_as_an_alias_to_put()
+    {
+        $this->valuestore->set('key', 'value');
+
+        $this->assertSame('value', $this->valuestore->get('key'));
+    }
+
+    /** @test */
     public function it_can_skip_writing_to_disk_if_putting_empty_array()
     {
         $this->valuestore->put('key', 'value');


### PR DESCRIPTION
This adds an alias from `set($key, $value)` to `put($key, $value)`.

Obviously this is not needed, but it means that the Valuestore now shares the same API as the [illuminate configuration repository](https://laravel.com/api/5.7/Illuminate/Contracts/Config/Repository.html). I've personally gone to write `set` a few times and realised I had to use `put`.

Just a suggestion from my own experience with the package, I can always add it to an extended class if it isn't wanted.