### PR TITLE
Update @return information in get() docblock

### DIFF
--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -144,7 +144,7 @@ class Valuestore implements ArrayAccess, Countable
      * @param string $name
      * @param $default
      *
-     * @return null|string
+     * @return null|string|array
      */
     public function get(string $name, $default = null)
     {


### PR DESCRIPTION
The `get()` method of the ValueStore can also return arrays.
See the test in https://github.com/spatie/valuestore/blob/master/tests/ValuestoreTest.php#L46