### PR TITLE
Improve PHPUnit fixtures

### DIFF
--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -13,7 +13,7 @@ class ValuestoreTest extends TestCase
     /** @var \Spatie\Valuestore\Valuestore */
     protected $valuestore;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
According to the official [PHPUnit doc](https://phpunit.readthedocs.io/en/9.3//fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void` method.