### PR TITLE
Feature/cleanup for 8

### DIFF
--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -141,9 +141,9 @@ class Valuestore implements ArrayAccess, Countable
      * Get a value from the store.
      *
      * @param string $name
-     * @param $default
+     * @param array|string|float|int|null $default
      *
-     * @return null|string|array
+     * @return array|string|float|int|null
      */
     public function get(string $name, $default = null): array|string|float|int|null
     {
@@ -249,7 +249,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @param string $name
      *
-     * @return null|string
+     * @return array|string|float|int|null
      */
     public function pull(string $name): array|string|float|int|null
     {

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -15,7 +15,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public static function make(string $fileName, array $values = null): static
+    public static function make(string $fileName, ?array $values = null): static
     {
         $valuestore = (new static())->setFileName($fileName);
 

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -47,8 +47,8 @@ class Valuestore implements ArrayAccess, Countable
     /**
      * Put a value in the store.
      *
-     * @param string|array    $name
-     * @param string|int|null $value
+     * @param array|string                $name
+     * @param array|string|float|int|null $value
      *
      * @return $this
      */
@@ -75,7 +75,7 @@ class Valuestore implements ArrayAccess, Countable
      * Push a new value into an array.
      *
      * @param string $name
-     * @param $pushValue
+     * @param array|string|float|int|null $pushValue
      *
      * @return $this
      */
@@ -108,7 +108,7 @@ class Valuestore implements ArrayAccess, Countable
      * Prepend a new value in an array.
      *
      * @param string $name
-     * @param $prependValue
+     * @param array|string|float|int|null $prependValue
      *
      * @return $this
      */

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -52,7 +52,10 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function put(array|string $name, $value = null): static
+    public function put(
+        array|string $name,
+        array|string|float|int|null $value = null
+    ): static
     {
         if ($name === []) {
             return $this;

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -375,11 +375,6 @@ class Valuestore implements ArrayAccess, Countable
         return substr($haystack, 0, strlen($needle)) === $needle;
     }
 
-    /**
-     * @param array $values
-     *
-     * @return $this
-     */
     protected function setContent(array $values)
     {
         file_put_contents($this->fileName, json_encode($values));

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -158,6 +158,8 @@ class Valuestore implements ArrayAccess, Countable
 
     /*
      * Determine if the store has a value for the given name.
+     *
+     * @return bool
      */
     public function has(string $name): bool
     {

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -145,7 +145,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return null|string|array
      */
-    public function get(string $name, $default = null)
+    public function get(string $name, $default = null): array|string|float|int|null
     {
         $all = $this->all();
 
@@ -251,7 +251,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return null|string
      */
-    public function pull(string $name)
+    public function pull(string $name): array|string|float|int|null
     {
         $value = $this->get($name);
 

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -118,7 +118,10 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function prepend(string $name, $prependValue): static
+    public function prepend(
+        string $name,
+        array|string|float|int|null $prependValue
+    ): static
     {
         if (! is_array($prependValue)) {
             $prependValue = [$prependValue];

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -7,8 +7,7 @@ use Countable;
 
 class Valuestore implements ArrayAccess, Countable
 {
-    /** @var string */
-    protected $fileName;
+    protected string $fileName;
 
     /**
      * @param string $fileName

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -15,7 +15,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public static function make(string $fileName, array $values = null)
+    public static function make(string $fileName, array $values = null): static
     {
         $valuestore = (new static())->setFileName($fileName);
 
@@ -37,7 +37,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    protected function setFileName(string $fileName)
+    protected function setFileName(string $fileName): static
     {
         $this->fileName = $fileName;
 
@@ -52,7 +52,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function put($name, $value = null)
+    public function put($name, $value = null): static
     {
         if ($name == []) {
             return $this;
@@ -79,7 +79,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function push(string $name, $pushValue)
+    public function push(string $name, $pushValue): static
     {
         if (! is_array($pushValue)) {
             $pushValue = [$pushValue];
@@ -112,7 +112,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function prepend(string $name, $prependValue)
+    public function prepend(string $name, $prependValue): static
     {
         if (! is_array($prependValue)) {
             $prependValue = [$prependValue];
@@ -203,7 +203,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function forget(string $key)
+    public function forget(string $key): static
     {
         $newContent = $this->all();
 
@@ -219,7 +219,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function flush()
+    public function flush(): static
     {
         return $this->setContent([]);
     }
@@ -231,7 +231,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function flushStartingWith(string $startingWith = '')
+    public function flushStartingWith(string $startingWith = ''): static
     {
         $newContent = [];
 

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -235,15 +235,14 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Increment a value from the store.
-     *
-     * @param string $name
-     * @param int    $by
-     *
-     * @return string|int|null
      */
-    public function increment(string $name, int $by = 1)
+    public function increment(string $name, int $by = 1): array|string|int|float|null
     {
         $currentValue = $this->get($name) ?? 0;
+
+        if (! $this->isNumber($currentValue)) {
+            return $currentValue;
+        }
 
         $newValue = $currentValue + $by;
 
@@ -253,14 +252,17 @@ class Valuestore implements ArrayAccess, Countable
     }
 
     /**
-     * Decrement a value from the store.
-     *
-     * @param string $name
-     * @param int    $by
-     *
-     * @return string|int|null
+     * Determine if the value can be incremented or decremented.
      */
-    public function decrement(string $name, int $by = 1)
+    public function isNumber($value): bool
+    {
+        return is_int($value) || is_float($value);
+    }
+
+    /**
+     * Decrement a value from the store.
+     */
+    public function decrement(string $name, int $by = 1): array|string|int|float|null
     {
         return $this->increment($name, $by * -1);
     }

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -82,7 +82,10 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function push(string $name, $pushValue): static
+    public function push(
+        string $name,
+        array|string|float|int|null $pushValue
+    ): static
     {
         if (! is_array($pushValue)) {
             $pushValue = [$pushValue];

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -10,9 +10,6 @@ class Valuestore implements ArrayAccess, Countable
     protected string $fileName;
 
     /**
-     * @param string $fileName
-     * @param array|null $values
-     *
      * @return $this
      */
     public static function make(string $fileName, ?array $values = null): static
@@ -33,8 +30,6 @@ class Valuestore implements ArrayAccess, Countable
     /**
      * Set the filename where all values will be stored.
      *
-     * @param string $fileName
-     *
      * @return $this
      */
     protected function setFileName(string $fileName): static
@@ -47,16 +42,12 @@ class Valuestore implements ArrayAccess, Countable
     /**
      * Put a value in the store.
      *
-     * @param array|string                $name
-     * @param array|string|float|int|null $value
-     *
      * @return $this
      */
     public function put(
         array|string $name,
         array|string|float|int|null $value = null
-    ): static
-    {
+    ): static {
         if ($name === []) {
             return $this;
         }
@@ -77,16 +68,12 @@ class Valuestore implements ArrayAccess, Countable
     /**
      * Push a new value into an array.
      *
-     * @param string $name
-     * @param array|string|float|int|null $pushValue
-     *
      * @return $this
      */
     public function push(
         string $name,
         array|string|float|int|null $pushValue
-    ): static
-    {
+    ): static {
         if (! is_array($pushValue)) {
             $pushValue = [$pushValue];
         }
@@ -113,16 +100,12 @@ class Valuestore implements ArrayAccess, Countable
     /**
      * Prepend a new value in an array.
      *
-     * @param string $name
-     * @param array|string|float|int|null $prependValue
-     *
      * @return $this
      */
     public function prepend(
         string $name,
         array|string|float|int|null $prependValue
-    ): static
-    {
+    ): static {
         if (! is_array($prependValue)) {
             $prependValue = [$prependValue];
         }
@@ -148,17 +131,11 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Get a value from the store.
-     *
-     * @param string $name
-     * @param array|string|float|int|null $default
-     *
-     * @return array|string|float|int|null
      */
     public function get(
         string $name,
         array|string|float|int|null $default = null
-    ): array|string|float|int|null
-    {
+    ): array|string|float|int|null {
         $all = $this->all();
 
         if (! array_key_exists($name, $all)) {
@@ -170,8 +147,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /*
      * Determine if the store has a value for the given name.
-     *
-     * @return bool
      */
     public function has(string $name): bool
     {
@@ -180,8 +155,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Get all values from the store.
-     *
-     * @return array
      */
     public function all(): array
     {
@@ -194,10 +167,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Get all keys starting with a given string from the store.
-     *
-     * @param string $startingWith
-     *
-     * @return array
      */
     public function allStartingWith(string $startingWith = ''): array
     {
@@ -212,8 +181,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Forget a value from the store.
-     *
-     * @param string $key
      *
      * @return $this
      */
@@ -241,8 +208,6 @@ class Valuestore implements ArrayAccess, Countable
     /**
      * Flush all values which keys start with a given string.
      *
-     * @param string $startingWith
-     *
      * @return $this
      */
     public function flushStartingWith(string $startingWith = ''): static
@@ -258,10 +223,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Get and forget a value from the store.
-     *
-     * @param string $name
-     *
-     * @return array|string|float|int|null
      */
     public function pull(string $name): array|string|float|int|null
     {
@@ -306,7 +267,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Whether a offset exists.
-     *
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
      *
      * @param mixed $offset
@@ -320,7 +280,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Offset to retrieve.
-     *
      * @link http://php.net/manual/en/arrayaccess.offsetget.php
      *
      * @param mixed $offset
@@ -334,7 +293,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Offset to set.
-     *
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
      *
      * @param mixed $offset
@@ -347,7 +305,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Offset to unset.
-     *
      * @link http://php.net/manual/en/arrayaccess.offsetunset.php
      *
      * @param mixed $offset
@@ -359,7 +316,6 @@ class Valuestore implements ArrayAccess, Countable
 
     /**
      * Count elements.
-     *
      * @link http://php.net/manual/en/countable.count.php
      *
      * @return int

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -360,20 +360,15 @@ class Valuestore implements ArrayAccess, Countable
     protected function filterKeysStartingWith(array $values, string $startsWith): array
     {
         return array_filter($values, function ($key) use ($startsWith) {
-            return $this->startsWith($key, $startsWith);
+            return str_starts_with($key, $startsWith);
         }, ARRAY_FILTER_USE_KEY);
     }
 
     protected function filterKeysNotStartingWith(array $values, string $startsWith): array
     {
         return array_filter($values, function ($key) use ($startsWith) {
-            return ! $this->startsWith($key, $startsWith);
+            return ! str_starts_with($key, $startsWith);
         }, ARRAY_FILTER_USE_KEY);
-    }
-
-    protected function startsWith(string $haystack, string $needle): bool
-    {
-        return substr($haystack, 0, strlen($needle)) === $needle;
     }
 
     protected function setContent(array $values)

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -266,7 +266,7 @@ class Valuestore implements ArrayAccess, Countable
      * @param string $name
      * @param int    $by
      *
-     * @return int|null|string
+     * @return string|int|null
      */
     public function increment(string $name, int $by = 1)
     {
@@ -285,7 +285,7 @@ class Valuestore implements ArrayAccess, Countable
      * @param string $name
      * @param int    $by
      *
-     * @return int|null|string
+     * @return string|int|null
      */
     public function decrement(string $name, int $by = 1)
     {

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -54,7 +54,7 @@ class Valuestore implements ArrayAccess, Countable
      */
     public function put($name, $value = null): static
     {
-        if ($name == []) {
+        if ($name === []) {
             return $this;
         }
 

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -154,7 +154,10 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return array|string|float|int|null
      */
-    public function get(string $name, $default = null): array|string|float|int|null
+    public function get(
+        string $name,
+        array|string|float|int|null $default = null
+    ): array|string|float|int|null
     {
         $all = $this->all();
 

--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -52,7 +52,7 @@ class Valuestore implements ArrayAccess, Countable
      *
      * @return $this
      */
-    public function put($name, $value = null): static
+    public function put(array|string $name, $value = null): static
     {
         if ($name === []) {
             return $this;

--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -356,6 +356,26 @@ class ValuestoreTest extends TestCase
     }
 
     /** @test */
+    public function it_cannot_increment_a_string_value()
+    {
+        $this->valuestore->put('string', 'test');
+
+        $this->valuestore->increment('string');
+
+        $this->assertSame('test', $this->valuestore->get('string'));
+    }
+
+    /** @test */
+    public function it_cannot_increment_a_null_value()
+    {
+        $this->valuestore->put('null', null);
+
+        $this->valuestore->increment('string');
+
+        $this->assertSame(null, $this->valuestore->get('null'));
+    }
+
+    /** @test */
     public function it_can_decrement_a_new_value()
     {
         $returnValue = $this->valuestore->decrement('number');
@@ -391,6 +411,27 @@ class ValuestoreTest extends TestCase
         $this->assertSame(-4, $returnValue);
 
         $this->assertSame(-4, $this->valuestore->get('number'));
+    }
+
+
+    /** @test */
+    public function it_cannot_decrement_a_string_value()
+    {
+        $this->valuestore->put('string', 'test');
+
+        $this->valuestore->increment('string');
+
+        $this->assertSame('test', $this->valuestore->get('string'));
+    }
+
+    /** @test */
+    public function it_cannot_decrement_a_null_value()
+    {
+        $this->valuestore->put('null', null);
+
+        $this->valuestore->increment('string');
+
+        $this->assertSame(null, $this->valuestore->get('null'));
     }
 
     /** @test */

--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -413,7 +413,6 @@ class ValuestoreTest extends TestCase
         $this->assertSame(-4, $this->valuestore->get('number'));
     }
 
-
     /** @test */
     public function it_cannot_decrement_a_string_value()
     {

--- a/tests/ValuestoreTest.php
+++ b/tests/ValuestoreTest.php
@@ -124,6 +124,14 @@ class ValuestoreTest extends TestCase
     }
 
     /** @test */
+    public function it_can_store_a_float()
+    {
+        $this->valuestore->put('PI', 3.14159265359);
+
+        $this->assertSame(3.14159265359, $this->valuestore->get('PI'));
+    }
+
+    /** @test */
     public function it_provides_a_chainable_put_method()
     {
         $this->valuestore


### PR DESCRIPTION
Hello,

I'd like to propose some improvements:
- add a support for the `float` type
- add a type to the `fileName` field
- add a `static` return type to all methods that return $this (because it's PHP 8 only package)
- add explicit union type to the methods that output stored values (the union type is `array|string|float|int|null`)
- inline `startsWith` method (because it's PHP 8 only package and we can use a built-in function)

