### PR TITLE
amended get method (return $default value if the returned value is null)

### DIFF
--- a/src/Valuestore.php
+++ b/src/Valuestore.php
@@ -110,7 +110,7 @@ class Valuestore implements ArrayAccess, Countable
             return $default;
         }
 
-        return $all[$name];
+        return $all[$name] ?? $default;
     }
 
     public function has(string $name): bool


### PR DESCRIPTION
let's say in json file, 
```
{"somekey":null}
```

previously if we call `$valuestore->get('somekey', 'defaultvalue')` method, it will return null..
but it should return `defaultvalue` ...
so current workaround is to write `$valuestore->get('somekey', 'defaultvalue') ??  'defaultvalue'` which is quite annoying because need to write twice same code...

so, i make this PR to improve this....

now, if you approve this PR, when we call `$valuestore->get('somekey', 'defaultvalue')` method, it will simply return `defaultvalue` instead of null....

thank you.. hope can merge this...